### PR TITLE
fix(client)!: Enable timeout for the Graphql calls over HTTPX

### DIFF
--- a/pyaqueduct/client/client.py
+++ b/pyaqueduct/client/client.py
@@ -62,7 +62,9 @@ class AqueductClient(BaseModel):
         """
         super().__init__(url=HttpUrl(url), timeout=timeout)
 
-        self._gql_client = Client(transport=HTTPXTransport(url=f"{url}/graphql"))
+        self._gql_client = Client(
+            transport=HTTPXTransport(url=f"{url}/graphql", timeout=self.timeout)
+        )
         self.connect()
 
     def connect(self):


### PR DESCRIPTION
This PR resolves the issue raised here #3 about the timeout argument was not passed to the Graphql client connection handler.