### PR TITLE
fix(refactor): Make `AqueductClient` a private member of the `API` and `Experiment` classes.

### DIFF
--- a/pyaqueduct/api.py
+++ b/pyaqueduct/api.py
@@ -53,7 +53,7 @@ class API(BaseModel):
         experiment_data = self._client.create_experiment(title=title, description=description)
         return Experiment(
             client=self._client,
-            id=experiment_data.id,
+            experiment_id=experiment_data.id,
             alias=experiment_data.alias,
             created_at=experiment_data.created_at,
         )
@@ -71,7 +71,7 @@ class API(BaseModel):
         experiment_data = self._client.get_experiment_by_alias(alias=alias)
         return Experiment(
             client=self._client,
-            id=experiment_data.id,
+            experiment_id=experiment_data.id,
             alias=experiment_data.alias,
             created_at=experiment_data.created_at,
         )
@@ -92,7 +92,7 @@ class API(BaseModel):
         return [
             Experiment(
                 client=self._client,
-                id=experiment.id,
+                experiment_id=experiment.id,
                 alias=experiment.alias,
                 created_at=experiment.created_at,
             )

--- a/pyaqueduct/client/client.py
+++ b/pyaqueduct/client/client.py
@@ -115,7 +115,7 @@ class AqueductClient(BaseModel):
         return experiment_obj
 
     def update_experiment(
-        self, experiment_uuid: str, title: Optional[str] = None, description: Optional[str] = None
+        self, experiment_uuid: UUID, title: Optional[str] = None, description: Optional[str] = None
     ) -> ExperimentData:
         """
         Update title or description or both for experiment
@@ -138,7 +138,7 @@ class AqueductClient(BaseModel):
             experiment = self._gql_client.execute(
                 update_experiment_mutation,
                 variable_values={
-                    "experimentId": experiment_uuid,
+                    "experimentId": str(experiment_uuid),
                     "title": title,
                     "description": description,
                 },
@@ -215,7 +215,7 @@ class AqueductClient(BaseModel):
         )
         return experiments_obj
 
-    def get_experiment(self, experiment_uuid: str) -> ExperimentData:
+    def get_experiment(self, experiment_uuid: UUID) -> ExperimentData:
         """
         Get an Experiment by ID or Alias
 
@@ -228,7 +228,8 @@ class AqueductClient(BaseModel):
         """
         try:
             experiment = self._gql_client.execute(
-                get_experiment_query, variable_values={"type": "UUID", "value": experiment_uuid}
+                get_experiment_query,
+                variable_values={"type": "UUID", "value": str(experiment_uuid)},
             )
         except gql_exceptions.TransportServerError as error:
             if error.code:
@@ -275,7 +276,7 @@ class AqueductClient(BaseModel):
         logging.info("Fetched experiment - %s", experiment_obj.title)
         return experiment_obj
 
-    def add_tag_to_experiment(self, experiment_uuid: str, tag: str) -> ExperimentData:
+    def add_tag_to_experiment(self, experiment_uuid: UUID, tag: str) -> ExperimentData:
         """
         Add a tag to an experiment
 
@@ -289,7 +290,7 @@ class AqueductClient(BaseModel):
         try:
             experiment = self._gql_client.execute(
                 add_tag_to_experiment_mutation,
-                variable_values={"experimentId": experiment_uuid, "tag": tag},
+                variable_values={"experimentId": str(experiment_uuid), "tag": tag},
             )
         except gql_exceptions.TransportServerError as error:
             if error.code:
@@ -306,7 +307,7 @@ class AqueductClient(BaseModel):
         logging.info("Added tag %s to experiment <%s>", tag, experiment_obj.title)
         return experiment_obj
 
-    def remove_tag_from_experiment(self, experiment_uuid: str, tag: str) -> ExperimentData:
+    def remove_tag_from_experiment(self, experiment_uuid: UUID, tag: str) -> ExperimentData:
         """
         Remove a tag from an experiment
 
@@ -320,7 +321,7 @@ class AqueductClient(BaseModel):
         try:
             experiment = self._gql_client.execute(
                 remove_tag_from_experiment_mutation,
-                variable_values={"experimentId": experiment_uuid, "tag": tag},
+                variable_values={"experimentId": str(experiment_uuid), "tag": tag},
             )
         except gql_exceptions.TransportServerError as error:
             if error.code:

--- a/pyaqueduct/client/types.py
+++ b/pyaqueduct/client/types.py
@@ -47,9 +47,8 @@ class ExperimentData:
             tags=data["tags"],
             alias=data["alias"],
             files=[ExperimentFile.from_dict(file_data) for file_data in data["files"]],
-            # fix timezone to work in Python versions older than 3.11.
-            created_at=datetime.fromisoformat(cast(str, data["createdAt"]).replace("Z", "+00:00")),
-            updated_at=datetime.fromisoformat(cast(str, data["updatedAt"]).replace("Z", "+00:00")),
+            created_at=datetime.fromisoformat(data["createdAt"]),
+            updated_at=datetime.fromisoformat(data["updatedAt"]),
         )
 
 

--- a/pyaqueduct/client/types.py
+++ b/pyaqueduct/client/types.py
@@ -1,7 +1,8 @@
 """Dataclasses for experiment and it's components"""
+
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List
+from typing import List, cast
 from uuid import UUID
 
 
@@ -46,8 +47,9 @@ class ExperimentData:
             tags=data["tags"],
             alias=data["alias"],
             files=[ExperimentFile.from_dict(file_data) for file_data in data["files"]],
-            created_at=datetime.fromisoformat(data["createdAt"]),
-            updated_at=datetime.fromisoformat(data["updatedAt"]),
+            # fix timezone to work in Python versions older than 3.11.
+            created_at=datetime.fromisoformat(cast(str, data["createdAt"]).replace("Z", "+00:00")),
+            updated_at=datetime.fromisoformat(cast(str, data["updatedAt"]).replace("Z", "+00:00")),
         )
 
 

--- a/pyaqueduct/client/types.py
+++ b/pyaqueduct/client/types.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, cast
+from typing import List
 from uuid import UUID
 
 

--- a/pyaqueduct/experiment.py
+++ b/pyaqueduct/experiment.py
@@ -44,7 +44,7 @@ class Experiment(BaseModel):
     @property
     def title(self) -> str:
         """Get title of experiment."""
-        return self._client.get_experiment(experiment_uuid=str(self.id)).title
+        return self._client.get_experiment(experiment_uuid=self.id).title
 
     @title.setter
     def title(self, value: str = Field(..., max_length=_MAX_TITLE_LENGTH)) -> None:
@@ -54,12 +54,12 @@ class Experiment(BaseModel):
             value: New title.
 
         """
-        self._client.update_experiment(experiment_uuid=str(self.id), title=value)
+        self._client.update_experiment(experiment_uuid=self.id, title=value)
 
     @property
     def description(self) -> str:
         """Get description of experiment."""
-        return self._client.get_experiment(str(self.id)).description
+        return self._client.get_experiment(self.id).description
 
     @description.setter
     def description(self, value: str = Field(..., max_length=_MAX_DESCRIPTION_LENGTH)) -> None:
@@ -69,12 +69,12 @@ class Experiment(BaseModel):
             value: New description.
 
         """
-        self._client.update_experiment(experiment_uuid=str(self.id), description=value)
+        self._client.update_experiment(experiment_uuid=self.id, description=value)
 
     @property
     def tags(self) -> List[str]:
         """Gets tags of experiment."""
-        return self._client.get_experiment(str(self.id)).tags
+        return self._client.get_experiment(self.id).tags
 
     def add_tag(self, tag: str = Field(..., max_length=_MAX_TAG_LENGTH)) -> None:
         """Add new tag to experiment."""
@@ -83,18 +83,17 @@ class Experiment(BaseModel):
                 f"Tag {tag} should only contain alphanumeric characters, underscores or hyphens"
             )
 
-        self._client.add_tag_to_experiment(experiment_uuid=str(self.id), tag=tag)
+        self._client.add_tag_to_experiment(experiment_uuid=self.id, tag=tag)
 
     def remove_tag(self, tag: str = Field(..., max_length=_MAX_TAG_LENGTH)) -> None:
         """Remove tag from experiment."""
-        self._client.remove_tag_from_experiment(experiment_uuid=str(self.id), tag=tag)
+        self._client.remove_tag_from_experiment(experiment_uuid=self.id, tag=tag)
 
     @property
     def files(self) -> List[Tuple[str, datetime]]:
         """Get file names of expriment."""
         return [
-            (item.name, item.modified_at)
-            for item in self._client.get_experiment(str(self.id)).files
+            (item.name, item.modified_at) for item in self._client.get_experiment(self.id).files
         ]
 
     def download_file(self, file_name: str, destination_dir: str) -> None:
@@ -108,4 +107,4 @@ class Experiment(BaseModel):
     @property
     def updated_at(self) -> datetime:
         """Get last updated datetime of the experiment."""
-        return self._client.get_experiment(str(self.id)).updated_at
+        return self._client.get_experiment(self.id).updated_at

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -27,7 +27,7 @@ def test_create_experiment(monkeypatch):
 
 
 def test_update_experiment(monkeypatch):
-    experiment_uuid = f"{uuid4()}"
+    experiment_uuid = uuid4()
     expected_title = "test title"
     expected_description = "test description"
     expected_tags = []
@@ -55,7 +55,7 @@ def test_get_experiment(monkeypatch):
 
     client = AqueductClient(url="http://test.com", timeout=1)
 
-    experiment = client.get_experiment(str(experiment_id))
+    experiment = client.get_experiment(experiment_id)
     assert experiment.title == expected_title
     assert experiment.description == expected_description
     assert experiment.tags == expected_tags
@@ -86,7 +86,7 @@ def test_add_tag_to_experiment(monkeypatch):
 
     client = AqueductClient(url="http://test.com", timeout=1)
 
-    experiment = client.add_tag_to_experiment(experiment_uuid=f"{experiment_id}", tag=tag_name)
+    experiment = client.add_tag_to_experiment(experiment_uuid=experiment_id, tag=tag_name)
 
     assert tag_name in experiment.tags
 
@@ -99,7 +99,7 @@ def test_remove_tag_from_experiment(monkeypatch):
 
     client = AqueductClient(url="http://test.com", timeout=1)
 
-    experiment = client.remove_tag_from_experiment(experiment_uuid=f"{experiment_id}", tag=tag_name)
+    experiment = client.remove_tag_from_experiment(experiment_uuid=experiment_id, tag=tag_name)
 
     assert tag_name not in experiment.tags
 

--- a/tests/unittests/test_experiment.py
+++ b/tests/unittests/test_experiment.py
@@ -3,12 +3,7 @@ from collections import namedtuple
 from datetime import datetime
 from uuid import uuid4
 
-from pyaqueduct.client import (
-    AqueductClient,
-    ExperimentData,
-    ExperimentFile,
-    ExperimentsInfo,
-)
+from pyaqueduct.client import AqueductClient, ExperimentData, ExperimentFile
 from pyaqueduct.experiment import Experiment
 
 
@@ -46,7 +41,7 @@ def test_experiment_title(monkeypatch):
     mocked_client = AqueductClient(url="http://test.com", timeout=1)
     experiment = Experiment(
         client=mocked_client,
-        id=expected_id,
+        experiment_id=expected_id,
         alias=expected_alias,
         created_at=datetime.now(),
     )
@@ -89,7 +84,7 @@ def test_experiment_description(monkeypatch):
     mocked_client = AqueductClient(url="http://test.com", timeout=1)
     experiment = Experiment(
         client=mocked_client,
-        id=expected_id,
+        experiment_id=expected_id,
         alias=expected_alias,
         created_at=datetime.now(),
     )
@@ -151,7 +146,7 @@ def test_experiment_tags(monkeypatch):
     mocked_client = AqueductClient(url="http://test.com", timeout=1)
     experiment = Experiment(
         client=mocked_client,
-        id=expected_id,
+        experiment_id=expected_id,
         alias=expected_alias,
         created_at=datetime.now(),
     )
@@ -202,7 +197,7 @@ def test_experiment_files(monkeypatch):
     mocked_client = AqueductClient(url="http://test.com", timeout=1)
     experiment = Experiment(
         client=mocked_client,
-        id=expected_id,
+        experiment_id=expected_id,
         alias=expected_alias,
         created_at=datetime.now(),
     )


### PR DESCRIPTION
This PR makes the `client` member function of the API and Experiment class private so it won't be shown in the documentation and IDEs.