### PR TITLE
feat(experiment)!: Enable adding multiple tags to an experiment instead of adding one by one.

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -2,9 +2,9 @@ name: Static Analysis and Tests
 
 on:
   push:
-    branches: [main, feat-*]
+    branches: [main, feat/*]
   pull_request:
-    branches: [main, feat-*]
+    branches: [main, feat/*]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/semantic_pull_request.yaml
+++ b/.github/workflows/semantic_pull_request.yaml
@@ -2,7 +2,7 @@ name: Check Pull Request Title
 
 on:
   pull_request:
-    branches: [main, feat-*]
+    branches: [main, feat/*]
 
 jobs:
   semantic_pull_request:

--- a/examples/tutorial_notebook.ipynb
+++ b/examples/tutorial_notebook.ipynb
@@ -161,9 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "experiment.add_tag(\"motion\")\n",
-    "experiment.add_tag(\"simulation\")\n",
-    "experiment.add_tag(\"notebook\")\n",
+    "experiment.add_tags([\"motion\", \"simulation\", \"notebook\"])\n",
     "\n",
     "experiment.tags"
    ]

--- a/pyaqueduct/client/client.py
+++ b/pyaqueduct/client/client.py
@@ -23,7 +23,7 @@ from pyaqueduct.exceptions import (
     UnAuthorizedError,
 )
 from pyaqueduct.schemas.mutations import (
-    add_tag_to_experiment_mutation,
+    add_tags_to_experiment_mutation,
     create_experiment_mutation,
     remove_experiment_mutation,
     remove_tag_from_experiment_mutation,
@@ -279,13 +279,13 @@ class AqueductClient(BaseModel):
         logging.info("Fetched experiment - %s", experiment_obj.title)
         return experiment_obj
 
-    def add_tag_to_experiment(self, experiment_uuid: UUID, tag: str) -> ExperimentData:
+    def add_tags_to_experiment(self, experiment_uuid: UUID, tags: List[str]) -> ExperimentData:
         """
-        Add a tag to an experiment
+        Add tags to an experiment.
 
         Args:
             experiment_uuid: UUID of experiment.
-            tag: Tag to be added to experiment.
+            tags: List of tags to be added to experiment.
 
         Returns:
             Updated experiment.
@@ -293,8 +293,8 @@ class AqueductClient(BaseModel):
         """
         try:
             experiment = self._gql_client.execute(
-                add_tag_to_experiment_mutation,
-                variable_values={"experimentId": str(experiment_uuid), "tag": tag},
+                add_tags_to_experiment_mutation,
+                variable_values={"experimentId": str(experiment_uuid), "tags": tags},
             )
         except gql_exceptions.TransportServerError as error:
             if error.code:
@@ -306,9 +306,9 @@ class AqueductClient(BaseModel):
             ) from error
 
         experiment_obj = ExperimentData.from_dict(
-            experiment["addTagToExperiment"]  # pylint: disable=unsubscriptable-object
+            experiment["addTagsToExperiment"]  # pylint: disable=unsubscriptable-object
         )
-        logging.info("Added tag %s to experiment <%s>", tag, experiment_obj.title)
+        logging.info("Added tags %s to experiment <%s>", tags, experiment_obj.title)
         return experiment_obj
 
     def remove_experiment(self, experiment_uuid: UUID) -> None:

--- a/pyaqueduct/experiment.py
+++ b/pyaqueduct/experiment.py
@@ -90,12 +90,12 @@ class Experiment(BaseModel):
 
         """
 
-        for tag in tags:
-            if not is_valid_tag(tag):
-                raise ValueError(
-                    f"Tag {tag} should only contain alphanumeric characters, "
-                    "underscores or hyphens."
-                )
+        invalid_tags = [tag for tag in tags if not is_valid_tag(tag)]
+        if invalid_tags:
+            raise ValueError(
+                f"Tags {invalid_tags} should only contain alphanumeric characters, "
+                "underscores or hyphens."
+            )
 
         self._client.add_tags_to_experiment(experiment_uuid=self.id, tags=tags)
 

--- a/pyaqueduct/experiment.py
+++ b/pyaqueduct/experiment.py
@@ -8,12 +8,15 @@ from typing import List, Tuple
 from uuid import UUID
 
 from pydantic import BaseModel, Field, validate_call
+from typing_extensions import Annotated
 
 from pyaqueduct.client import AqueductClient
 
 _MAX_TITLE_LENGTH = 100
 _MAX_DESCRIPTION_LENGTH = 2000
 _MAX_TAG_LENGTH = 50
+
+TagString = Annotated[str, Field(..., max_length=_MAX_TAG_LENGTH)]
 
 
 def is_valid_tag(tag: str) -> bool:
@@ -79,14 +82,22 @@ class Experiment(BaseModel):
         return self._client.get_experiment(self.id).tags
 
     @validate_call
-    def add_tag(self, tag: str = Field(..., max_length=_MAX_TAG_LENGTH)) -> None:
-        """Add new tag to experiment."""
-        if not is_valid_tag(tag):
-            raise ValueError(
-                f"Tag {tag} should only contain alphanumeric characters, underscores or hyphens"
-            )
+    def add_tags(self, tags: List[TagString]) -> None:
+        """Add new tags to experiment.
 
-        self._client.add_tag_to_experiment(experiment_uuid=self.id, tag=tag)
+        Args:
+            tags: List of tags to be added to the experiment.
+
+        """
+
+        for tag in tags:
+            if not is_valid_tag(tag):
+                raise ValueError(
+                    f"Tag {tags} should only contain alphanumeric characters, "
+                    "underscores or hyphens."
+                )
+
+        self._client.add_tags_to_experiment(experiment_uuid=self.id, tags=tags)
 
     @validate_call
     def remove_tag(self, tag: str = Field(..., max_length=_MAX_TAG_LENGTH)) -> None:

--- a/pyaqueduct/experiment.py
+++ b/pyaqueduct/experiment.py
@@ -93,7 +93,7 @@ class Experiment(BaseModel):
         for tag in tags:
             if not is_valid_tag(tag):
                 raise ValueError(
-                    f"Tag {tags} should only contain alphanumeric characters, "
+                    f"Tag {tag} should only contain alphanumeric characters, "
                     "underscores or hyphens."
                 )
 

--- a/pyaqueduct/schemas/mutations.py
+++ b/pyaqueduct/schemas/mutations.py
@@ -64,16 +64,16 @@ update_experiment_mutation = gql(
     """
 )
 
-add_tag_to_experiment_mutation = gql(
+add_tags_to_experiment_mutation = gql(
     """
     mutation AddTagToExperiment (
         $experimentId: UUID!,
-        $tag: String!
+        $tags: [String!]!
     ) {
-        addTagToExperiment (
-            experimentTagInput: {
+        addTagsToExperiment(
+            experimentTagsInput: {
                 experimentId: $experimentId,
-                tag: $tag
+                tags: $tags
             }
         ) {
             id

--- a/tests/unittests/mock.py
+++ b/tests/unittests/mock.py
@@ -1,7 +1,7 @@
 from uuid import uuid4
 
 from pyaqueduct.schemas.mutations import (
-    add_tag_to_experiment_mutation,
+    add_tags_to_experiment_mutation,
     create_experiment_mutation,
     remove_tag_from_experiment_mutation,
     update_experiment_mutation,
@@ -76,14 +76,14 @@ def patched_execute(self, query, variable_values, **kwargs):
             }
         }
 
-    elif query == add_tag_to_experiment_mutation:
+    elif query == add_tags_to_experiment_mutation:
         return {
-            "addTagToExperiment": {
+            "addTagsToExperiment": {
                 "id": variable_values["experimentId"],
                 "title": "test title",
                 "description": "test description",
                 "alias": "230101-01",
-                "tags": variable_values["tag"],
+                "tags": variable_values["tags"],
                 "files": [],
                 "createdAt": "2024-01-03T18:03:46.135824",
                 "updatedAt": "2024-01-03T18:03:46.135829",

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -132,17 +132,17 @@ def test_get_experiments_with_filters(monkeypatch):
     assert experiments.experiments[1].description == "test description 2"
 
 
-def test_add_tag_to_experiment(monkeypatch):
+def test_add_tags_to_experiment(monkeypatch):
     experiment_id = uuid4()
-    tag_name = "tag"
 
+    expected_tags = ["tag1", "tag2"]
     monkeypatch.setattr(SyncClientSession, "execute", patched_execute)
 
     client = AqueductClient(url="http://test.com", timeout=1)
 
-    experiment = client.add_tag_to_experiment(experiment_uuid=experiment_id, tag=tag_name)
+    experiment = client.add_tags_to_experiment(experiment_uuid=experiment_id, tags=expected_tags)
 
-    assert tag_name in experiment.tags
+    assert expected_tags == experiment.tags
 
 
 def test_remove_experiment(monkeypatch):

--- a/tests/unittests/test_experiment.py
+++ b/tests/unittests/test_experiment.py
@@ -112,9 +112,9 @@ def test_experiment_tags(monkeypatch):
             tags=expected_tags,
         )
 
-    def patched_add_tag_to_experiment(self, experiment_uuid, tag):
-        assert tag == "tag4"
-        expected_tags.append(tag)
+    def patched_add_tags_to_experiment(self, experiment_uuid, tags):
+        assert tags == ["tag4", "tag5"]
+        expected_tags.extend(tags)
         return ExperimentData(
             id=experiment_uuid,
             title=expected_title,
@@ -139,7 +139,7 @@ def test_experiment_tags(monkeypatch):
         )
 
     monkeypatch.setattr(AqueductClient, "get_experiment", patched_get_experiment)
-    monkeypatch.setattr(AqueductClient, "add_tag_to_experiment", patched_add_tag_to_experiment)
+    monkeypatch.setattr(AqueductClient, "add_tags_to_experiment", patched_add_tags_to_experiment)
     monkeypatch.setattr(
         AqueductClient, "remove_tag_from_experiment", patched_remove_tag_from_experiment
     )
@@ -152,11 +152,11 @@ def test_experiment_tags(monkeypatch):
     )
 
     assert experiment.tags == expected_tags
-    experiment.add_tag("tag4")
-    assert expected_tags == ["tag1", "tag2", "tag3", "tag4"]
+    experiment.add_tags(["tag4", "tag5"])
+    assert expected_tags == ["tag1", "tag2", "tag3", "tag4", "tag5"]
     assert experiment.tags == expected_tags
     experiment.remove_tag("tag4")
-    assert expected_tags == ["tag1", "tag2", "tag3"]
+    assert expected_tags == ["tag1", "tag2", "tag3", "tag5"]
     assert experiment.tags == expected_tags
 
 


### PR DESCRIPTION
This PR changes the signature and behaviour of the `add_tag` method of the Experiment class to support adding multiple tags in one call following the support in the GraphQL API. The tests are updated as well.