### PR TITLE
fix(api)!: Enhance API by renaming alias to EID and id to UUID

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -45,4 +45,5 @@ jobs:
 
       - name: Build docs
         run: |
+          poetry run scripts/build_tutorial.sh && \
           poetry run mike deploy --push ${{ steps.extract_branch.outputs.branch }}

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+docs/getting-started.md

--- a/examples/tutorial_notebook.ipynb
+++ b/examples/tutorial_notebook.ipynb
@@ -145,7 +145,7 @@
     "    title=\"Motion Simulation Experiment\", description=\"Tutorial experiment: motion simulation.\"\n",
     ")\n",
     "\n",
-    "print(f\"Experiment created with unique id: {experiment.alias}\")"
+    "print(f\"Experiment created with unique id: {experiment.eid}\")"
    ]
   },
   {
@@ -263,7 +263,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "experiment = api.get_experiment(\"[Experiment ID]\")\n",
+    "experiment = api.get_experiment(experiment.eid)\n",
     "\n",
     "print(f\"Experiment title: {experiment.title}\")\n",
     "print(f\"Experiment title: {experiment.description}\")\n",
@@ -288,7 +288,7 @@
     "from datetime import datetime, timedelta\n",
     "\n",
     "# Search through the experiments by their title or experiment ID. It will return all experiments where search string is a substring of the title or the experiment ID\n",
-    "experiments_list = api.find_experiments(search=\"[search criteria, experiment title or alias]\")\n",
+    "experiments_list = api.find_experiments(search=\"[search criteria, experiment title or EID]\")\n",
     "\n",
     "# Find experiments that the ALL of provided tags in the argument are assigned them. It is an AND operation between the tags when searching through experiments.\n",
     "experiments_list = api.find_experiments(tags=[\"tag1\", \"tag2\"])\n",
@@ -326,7 +326,7 @@
    "source": [
     "# Experiments and their files can be removed from the database. Use it with caution\n",
     "# as this operation is not revertible.\n",
-    "api.remove_experiment(alias=\"[experiment alias]\")"
+    "api.remove_experiment_by_eid(eid=\"[experiment EID]\")"
    ]
   }
  ],

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -64,6 +64,7 @@ plugins:
 
 nav:
   - "index.md"
+  - "getting-started.md"
   - "api-reference.md"
   - "Aqueduct Core Documentation": "https://aqueducthub.github.io/aqueductcore/"
 

--- a/pyaqueduct/api.py
+++ b/pyaqueduct/api.py
@@ -64,40 +64,40 @@ class API(BaseModel):
         experiment_data = self._client.create_experiment(title=title, description=description)
         return Experiment(
             client=self._client,
-            experiment_id=experiment_data.id,
-            alias=experiment_data.alias,
+            uuid=experiment_data.uuid,
+            eid=experiment_data.eid,
             created_at=experiment_data.created_at,
         )
 
     @validate_call
-    def get_experiment(self, alias: str) -> Experiment:
+    def get_experiment(self, eid: str) -> Experiment:
         """Get the experiment by the specified identifier to operate on.
 
         Args:
-            alias: Alias of the specified experiment.
+            eid: EID of the specified experiment.
 
         Returns:
             Experiment object to interact with the experiment data.
 
         """
-        experiment_data = self._client.get_experiment_by_alias(alias=alias)
+        experiment_data = self._client.get_experiment_by_eid(eid=eid)
         return Experiment(
             client=self._client,
-            experiment_id=experiment_data.id,
-            alias=experiment_data.alias,
+            uuid=experiment_data.uuid,
+            eid=experiment_data.eid,
             created_at=experiment_data.created_at,
         )
 
     @validate_call
-    def remove_experiment_by_alias(self, alias: str) -> None:
+    def remove_experiment_by_eid(self, eid: str) -> None:
         """Remove experiment from the database. Experiment's files will be also removed.
 
         Args:
-            alias: Alias of the specified experiment.
+            eid: EID of the specified experiment.
 
         """
-        experiment_data = self._client.get_experiment_by_alias(alias=alias)
-        self._client.remove_experiment(experiment_uuid=experiment_data.id)
+        experiment_data = self._client.get_experiment_by_eid(eid=eid)
+        self._client.remove_experiment(experiment_uuid=experiment_data.uuid)
 
     @validate_call
     def find_experiments(
@@ -134,8 +134,8 @@ class API(BaseModel):
         return [
             Experiment(
                 client=self._client,
-                experiment_id=experiment.id,
-                alias=experiment.alias,
+                uuid=experiment.uuid,
+                eid=experiment.eid,
                 created_at=experiment.created_at,
             )
             for experiment in experiments

--- a/pyaqueduct/client/client.py
+++ b/pyaqueduct/client/client.py
@@ -112,7 +112,7 @@ class AqueductClient(BaseModel):
         experiment_obj = ExperimentData.from_dict(
             experiment["createExperiment"]  # pylint: disable=unsubscriptable-object
         )
-        logging.info("Created experiment - %s - %s", experiment_obj.id, experiment_obj.title)
+        logging.info("Created experiment - %s - %s", experiment_obj.uuid, experiment_obj.title)
         return experiment_obj
 
     def update_experiment(
@@ -140,7 +140,7 @@ class AqueductClient(BaseModel):
             experiment = self._gql_client.execute(
                 update_experiment_mutation,
                 variable_values={
-                    "experimentId": str(experiment_uuid),
+                    "uuid": str(experiment_uuid),
                     "title": title,
                     "description": description,
                 },
@@ -157,7 +157,7 @@ class AqueductClient(BaseModel):
         experiment_obj = ExperimentData.from_dict(
             experiment["updateExperiment"]  # pylint: disable=unsubscriptable-object
         )
-        logging.info("Updated experiment - %s", experiment_obj.id)
+        logging.info("Updated experiment - %s", experiment_obj.uuid)
         return experiment_obj
 
     def get_experiments(
@@ -175,7 +175,7 @@ class AqueductClient(BaseModel):
         Args:
             limit: Pagination field, number of experiments to be fetched.
             offset: Pagination field, number of experiments to skip.
-            title: Perform search on experiments through their title and alias.
+            title: Perform search on experiments through their title and eid.
             tags: Get experiments that have these tags.
             start_date: Start datetime to filter experiments (timezone aware).
             end_date: End datetime to filter experiments to (timezone aware).
@@ -249,12 +249,12 @@ class AqueductClient(BaseModel):
         logging.info("Fetched experiment - %s", experiment_obj.title)
         return experiment_obj
 
-    def get_experiment_by_alias(self, alias: str) -> ExperimentData:
+    def get_experiment_by_eid(self, eid: str) -> ExperimentData:
         """
-        Get an Experiment by Alias.
+        Get an Experiment by its EID.
 
         Args:
-            alias: Experiment's alias.
+            EID: Experiment's EID.
 
         Returns:
             Updated experiment.
@@ -262,7 +262,7 @@ class AqueductClient(BaseModel):
         """
         try:
             experiment = self._gql_client.execute(
-                get_experiment_query, variable_values={"type": "ALIAS", "value": alias}
+                get_experiment_query, variable_values={"type": "EID", "value": eid}
             )
         except gql_exceptions.TransportServerError as error:
             if error.code:
@@ -294,7 +294,7 @@ class AqueductClient(BaseModel):
         try:
             experiment = self._gql_client.execute(
                 add_tags_to_experiment_mutation,
-                variable_values={"experimentId": str(experiment_uuid), "tags": tags},
+                variable_values={"uuid": str(experiment_uuid), "tags": tags},
             )
         except gql_exceptions.TransportServerError as error:
             if error.code:
@@ -322,7 +322,7 @@ class AqueductClient(BaseModel):
         try:
             self._gql_client.execute(
                 remove_experiment_mutation,
-                variable_values={"experimentId": str(experiment_uuid)},
+                variable_values={"uuid": str(experiment_uuid)},
             )
         except gql_exceptions.TransportServerError as error:
             if error.code:
@@ -347,7 +347,7 @@ class AqueductClient(BaseModel):
         try:
             experiment = self._gql_client.execute(
                 remove_tag_from_experiment_mutation,
-                variable_values={"experimentId": str(experiment_uuid), "tag": tag},
+                variable_values={"uuid": str(experiment_uuid), "tag": tag},
             )
         except gql_exceptions.TransportServerError as error:
             if error.code:

--- a/pyaqueduct/client/client.py
+++ b/pyaqueduct/client/client.py
@@ -175,7 +175,7 @@ class AqueductClient(BaseModel):
         Args:
             limit: Pagination field, number of experiments to be fetched.
             offset: Pagination field, number of experiments to skip.
-            title: Perform search on experiments through their title and eid.
+            title: Perform search on experiments through their title and EID.
             tags: Get experiments that have these tags.
             start_date: Start datetime to filter experiments (timezone aware).
             end_date: End datetime to filter experiments to (timezone aware).

--- a/pyaqueduct/client/client.py
+++ b/pyaqueduct/client/client.py
@@ -251,7 +251,7 @@ class AqueductClient(BaseModel):
 
     def get_experiment_by_eid(self, eid: str) -> ExperimentData:
         """
-        Get an Experiment by its EID.
+        Get an experiment by its EID.
 
         Args:
             EID: Experiment's EID.

--- a/pyaqueduct/client/types.py
+++ b/pyaqueduct/client/types.py
@@ -28,7 +28,7 @@ class ExperimentFile:
 class ExperimentData:
     """Dataclass for experiment"""
 
-    uuid: UUID  # pylint: disable=invalid-name
+    uuid: UUID
     title: str
     description: str
     eid: str

--- a/pyaqueduct/client/types.py
+++ b/pyaqueduct/client/types.py
@@ -28,10 +28,10 @@ class ExperimentFile:
 class ExperimentData:
     """Dataclass for experiment"""
 
-    id: UUID  # pylint: disable=invalid-name
+    uuid: UUID  # pylint: disable=invalid-name
     title: str
     description: str
-    alias: str
+    eid: str
     created_at: datetime
     updated_at: datetime
     tags: List[str] = field(default_factory=list)
@@ -41,11 +41,11 @@ class ExperimentData:
     def from_dict(cls, data):
         """Convert experiment object to dictionary"""
         return cls(
-            id=UUID(data["id"]),
+            uuid=UUID(data["uuid"]),
             title=data["title"],
             description=data["description"],
             tags=data["tags"],
-            alias=data["alias"],
+            eid=data["eid"],
             files=[ExperimentFile.from_dict(file_data) for file_data in data["files"]],
             created_at=datetime.fromisoformat(data["createdAt"]),
             updated_at=datetime.fromisoformat(data["updatedAt"]),

--- a/pyaqueduct/experiment.py
+++ b/pyaqueduct/experiment.py
@@ -32,9 +32,9 @@ class Experiment(BaseModel):
     _client: AqueductClient
     "Client object reference."
     uuid: UUID
-    "UUID of the experiment."
+    "UUID of the experiment. This is an internal experiment identifier in the database"
     eid: str
-    "EID of the experiment."
+    "EID of the experiment. User-readable identifier, it is unique within one Aqueduct installation"
     created_at: datetime
     "Creation datetime of the experiment."
 

--- a/pyaqueduct/experiment.py
+++ b/pyaqueduct/experiment.py
@@ -31,23 +31,21 @@ class Experiment(BaseModel):
 
     _client: AqueductClient
     "Client object reference."
-    id: UUID
-    "Unique ID of the experiment."
-    alias: str
-    "Alias of the experiment."
+    uuid: UUID
+    "UUID of the experiment."
+    eid: str
+    "EID of the experiment."
     created_at: datetime
     "Creation datetime of the experiment."
 
-    def __init__(
-        self, experiment_id: UUID, alias: str, created_at: datetime, client: AqueductClient, **data
-    ):
-        super().__init__(id=experiment_id, alias=alias, created_at=created_at, **data)
+    def __init__(self, uuid: UUID, eid: str, created_at: datetime, client: AqueductClient, **data):
+        super().__init__(uuid=uuid, eid=eid, created_at=created_at, **data)
         self._client = client
 
     @property
     def title(self) -> str:
         """Get title of experiment."""
-        return self._client.get_experiment(experiment_uuid=self.id).title
+        return self._client.get_experiment(experiment_uuid=self.uuid).title
 
     @title.setter
     @validate_call
@@ -58,12 +56,12 @@ class Experiment(BaseModel):
             value: New title.
 
         """
-        self._client.update_experiment(experiment_uuid=self.id, title=value)
+        self._client.update_experiment(experiment_uuid=self.uuid, title=value)
 
     @property
     def description(self) -> str:
         """Get description of experiment."""
-        return self._client.get_experiment(self.id).description
+        return self._client.get_experiment(self.uuid).description
 
     @description.setter
     @validate_call
@@ -74,12 +72,12 @@ class Experiment(BaseModel):
             value: New description.
 
         """
-        self._client.update_experiment(experiment_uuid=self.id, description=value)
+        self._client.update_experiment(experiment_uuid=self.uuid, description=value)
 
     @property
     def tags(self) -> List[str]:
         """Gets tags of experiment."""
-        return self._client.get_experiment(self.id).tags
+        return self._client.get_experiment(self.uuid).tags
 
     @validate_call
     def add_tags(self, tags: List[TagString]) -> None:
@@ -97,31 +95,31 @@ class Experiment(BaseModel):
                 "underscores or hyphens."
             )
 
-        self._client.add_tags_to_experiment(experiment_uuid=self.id, tags=tags)
+        self._client.add_tags_to_experiment(experiment_uuid=self.uuid, tags=tags)
 
     @validate_call
     def remove_tag(self, tag: str = Field(..., max_length=_MAX_TAG_LENGTH)) -> None:
         """Remove tag from experiment."""
-        self._client.remove_tag_from_experiment(experiment_uuid=self.id, tag=tag)
+        self._client.remove_tag_from_experiment(experiment_uuid=self.uuid, tag=tag)
 
     @property
     def files(self) -> List[Tuple[str, datetime]]:
         """Get file names of expriment."""
         return [
-            (item.name, item.modified_at) for item in self._client.get_experiment(self.id).files
+            (item.name, item.modified_at) for item in self._client.get_experiment(self.uuid).files
         ]
 
     @validate_call
     def download_file(self, file_name: str, destination_dir: str) -> None:
         """Download the specified file of experiment."""
-        self._client.download_file(self.id, file_name=file_name, destination_dir=destination_dir)
+        self._client.download_file(self.uuid, file_name=file_name, destination_dir=destination_dir)
 
     @validate_call
     def upload_file(self, file: str) -> None:
         """Upload the specified file to experiment."""
-        self._client.upload_file(self.id, file=file)
+        self._client.upload_file(self.uuid, file=file)
 
     @property
     def updated_at(self) -> datetime:
         """Get last updated datetime of the experiment."""
-        return self._client.get_experiment(self.id).updated_at
+        return self._client.get_experiment(self.uuid).updated_at

--- a/pyaqueduct/schemas/mutations.py
+++ b/pyaqueduct/schemas/mutations.py
@@ -16,10 +16,10 @@ create_experiment_mutation = gql(
                 tags: $tags
             }
         ) {
-            id
+            uuid
             title
             description
-            alias
+            eid
             createdAt
             updatedAt
             tags
@@ -36,21 +36,21 @@ create_experiment_mutation = gql(
 update_experiment_mutation = gql(
     """
     mutation UpdateExperiment(
-        $experimentId: UUID!,
+        $uuid: UUID!,
         $title: String,
         $description: String
     ) {
         updateExperiment (
-            experimentId: $experimentId,
+            uuid: $uuid,
             experimentUpdateInput: {
                 title: $title,
                 description: $description
             }
         ) {
-            id
+            uuid
             title
             description
-            alias
+            eid
             createdAt
             updatedAt
             tags
@@ -67,19 +67,19 @@ update_experiment_mutation = gql(
 add_tags_to_experiment_mutation = gql(
     """
     mutation AddTagToExperiment (
-        $experimentId: UUID!,
+        $uuid: UUID!,
         $tags: [String!]!
     ) {
         addTagsToExperiment(
             experimentTagsInput: {
-                experimentId: $experimentId,
+                uuid: $uuid,
                 tags: $tags
             }
         ) {
-            id
+            uuid
             title
             description
-            alias
+            eid
             createdAt
             updatedAt
             tags
@@ -96,19 +96,19 @@ add_tags_to_experiment_mutation = gql(
 remove_tag_from_experiment_mutation = gql(
     """
     mutation RemoveTagFromExperiment (
-        $experimentId: UUID!,
+        $uuid: UUID!,
         $tag: String!
     ) {
         removeTagFromExperiment (
             experimentTagInput: {
-                experimentId: $experimentId,
+                uuid: $uuid,
                 tag: $tag
             }
         ) {
-            id
+            uuid
             title
             description
-            alias
+            eid
             createdAt
             updatedAt
             tags
@@ -125,9 +125,9 @@ remove_tag_from_experiment_mutation = gql(
 remove_experiment_mutation = gql(
     """
     mutation RemoveTagFromExperiment (
-        $experimentId: UUID!
+        $uuid: UUID!
         ) {
-        removeExperiment(experimentRemoveInput: {experimentId: $experimentId})
+        removeExperiment(experimentRemoveInput: {uuid: $uuid})
     }
     """
 )

--- a/pyaqueduct/schemas/queries.py
+++ b/pyaqueduct/schemas/queries.py
@@ -23,10 +23,10 @@ get_experiments_query = gql(
             offset: $offset,
         ) {
             experimentsData {
-                id
+                uuid
                 title
                 description
-                alias
+                eid
                 createdAt
                 updatedAt
                 tags
@@ -55,10 +55,10 @@ get_experiment_query = gql(
             type: $type,
         }
        ) {
-        id
+        uuid
         title
         description
-        alias
+        eid
         createdAt
         updatedAt
         tags

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -12,6 +12,7 @@ if [ -d "$PROJECT_ROOT/site" ]; then
     rm -rf $PROJECT_ROOT/site
 fi
 
+$SCRIPT_DIR/build_tutorial.sh
 
 # Build static website
 poetry run mkdocs build --clean --verbose

--- a/scripts/build_tutorial.sh
+++ b/scripts/build_tutorial.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# This script builds the docs
+
+FULL_PATH=$(realpath $0)
+SCRIPT_DIR=$(dirname $FULL_PATH)
+PROJECT_ROOT=$SCRIPT_DIR/..
+
+set -ex
+
+# convert tutorial notebook to markdown
+jupyter nbconvert --to markdown $PROJECT_ROOT/examples/tutorial_notebook.ipynb && \
+mv $PROJECT_ROOT/examples/tutorial_notebook.md $PROJECT_ROOT/docs/getting-started.md

--- a/tests/unittests/mock.py
+++ b/tests/unittests/mock.py
@@ -17,10 +17,10 @@ def patched_execute(self, query, variable_values, **kwargs):
     if query == create_experiment_mutation:
         return {
             "createExperiment": {
-                "id": f"{uuid4()}",
+                "uuid": f"{uuid4()}",
                 "title": variable_values["title"],
                 "description": variable_values["description"],
-                "alias": "230101-01",
+                "eid": "230101-01",
                 "tags": variable_values["tags"],
                 "files": [],
                 "createdAt": "2024-01-03T18:03:46.135824",
@@ -31,10 +31,10 @@ def patched_execute(self, query, variable_values, **kwargs):
     elif query == update_experiment_mutation:
         return {
             "updateExperiment": {
-                "id": variable_values["experimentId"],
+                "uuid": variable_values["uuid"],
                 "title": variable_values["title"],
                 "description": variable_values["description"],
-                "alias": "230101-01",
+                "eid": "230101-01",
                 "tags": [],
                 "files": [],
                 "createdAt": "2024-01-03T18:03:46.135824",
@@ -45,10 +45,10 @@ def patched_execute(self, query, variable_values, **kwargs):
     elif query == get_experiment_query:
         return {
             "experiment": {
-                "id": variable_values["value"],
+                "uuid": variable_values["value"],
                 "title": "test title",
                 "description": "test description",
-                "alias": "230101-01",
+                "eid": "230101-01",
                 "tags": [],
                 "createdAt": "2023-01-01T00:00:00",
                 "updatedAt": "2023-01-01T00:00:00",
@@ -61,10 +61,10 @@ def patched_execute(self, query, variable_values, **kwargs):
             "experiments": {
                 "experimentsData": [
                     {
-                        "id": f"{uuid4()}",
+                        "uuid": f"{uuid4()}",
                         "title": f"test title {idx}",
                         "description": f"test description {idx}",
-                        "alias": f"230101-0{idx}",
+                        "eid": f"230101-0{idx}",
                         "tags": [],
                         "createdAt": "2023-01-01T00:00:00",
                         "updatedAt": "2023-01-01T00:00:00",
@@ -79,10 +79,10 @@ def patched_execute(self, query, variable_values, **kwargs):
     elif query == add_tags_to_experiment_mutation:
         return {
             "addTagsToExperiment": {
-                "id": variable_values["experimentId"],
+                "uuid": variable_values["uuid"],
                 "title": "test title",
                 "description": "test description",
-                "alias": "230101-01",
+                "eid": "230101-01",
                 "tags": variable_values["tags"],
                 "files": [],
                 "createdAt": "2024-01-03T18:03:46.135824",
@@ -93,10 +93,10 @@ def patched_execute(self, query, variable_values, **kwargs):
     elif query == remove_tag_from_experiment_mutation:
         return {
             "removeTagFromExperiment": {
-                "id": variable_values["experimentId"],
+                "uuid": variable_values["uuid"],
                 "title": "test title",
                 "description": "test description",
-                "alias": "230101-01",
+                "eid": "230101-01",
                 "tags": [],
                 "files": [],
                 "createdAt": "2024-01-03T18:03:46.135824",

--- a/tests/unittests/test_api.py
+++ b/tests/unittests/test_api.py
@@ -11,18 +11,18 @@ def test_create_experiment(monkeypatch):
     expected_title = "test title"
     expected_description = "test description"
 
-    expected_id = uuid4()
-    expected_alias = "mock_alias"
+    expected_uuid = uuid4()
+    expected_eid = "mock_eid"
     expected_datetime = datetime.now()
 
     def patched_create_experiment(self, title, description):
         assert title == expected_title
         assert description == expected_description
         return ExperimentData(
-            id=expected_id,
+            uuid=expected_uuid,
             title=expected_title,
             description=expected_description,
-            alias=expected_alias,
+            eid=expected_eid,
             created_at=expected_datetime,
             updated_at=expected_datetime,
         )
@@ -32,76 +32,76 @@ def test_create_experiment(monkeypatch):
 
     experiment = api.create_experiment(title=expected_title, description=expected_description)
 
-    assert experiment.alias == expected_alias
-    assert experiment.id == expected_id
+    assert experiment.eid == expected_eid
+    assert experiment.uuid == expected_uuid
     assert experiment.created_at == expected_datetime
 
 
-def test_get_experiment_by_alias(monkeypatch):
-    expected_id = uuid4()
+def test_get_experiment_by_eid(monkeypatch):
+    expected_uuid = uuid4()
     expected_title = "test title"
     expected_description = "test description"
-    expected_alias = "mock_alias"
+    expected_eid = "mock_eid"
     expected_datetime = datetime.now()
 
-    def patched_get_experiment(self, alias):
+    def patched_get_experiment(self, eid):
         return ExperimentData(
-            id=expected_id,
+            uuid=expected_uuid,
             title=expected_title,
             description=expected_description,
-            alias=alias,
+            eid=eid,
             created_at=expected_datetime,
             updated_at=expected_datetime,
         )
 
-    monkeypatch.setattr(AqueductClient, "get_experiment_by_alias", patched_get_experiment)
+    monkeypatch.setattr(AqueductClient, "get_experiment_by_eid", patched_get_experiment)
     api = API(url="http://test.com", timeout=1)
 
-    experiment = api.get_experiment(alias=expected_alias)
+    experiment = api.get_experiment(eid=expected_eid)
 
-    assert experiment.alias == expected_alias
-    assert experiment.id == expected_id
+    assert experiment.eid == expected_eid
+    assert experiment.uuid == expected_uuid
     assert experiment.created_at == expected_datetime
 
 
-def test_remove_experiment_by_alias(monkeypatch):
-    expected_id = uuid4()
+def test_remove_experiment_by_eid(monkeypatch):
+    expected_uuid = uuid4()
     expected_title = "test title"
     expected_description = "test description"
-    expected_alias = "mock_alias"
+    expected_eid = "mock_eid"
     expected_datetime = datetime.now()
 
     def patched_remove_experiment(self, experiment_uuid):
-        assert experiment_uuid == expected_id
+        assert experiment_uuid == expected_uuid
 
-    def patched_get_experiment(self, alias):
-        assert alias == expected_alias
+    def patched_get_experiment(self, eid):
+        assert eid == expected_eid
 
         return ExperimentData(
-            id=expected_id,
+            uuid=expected_uuid,
             title=expected_title,
             description=expected_description,
-            alias=alias,
+            eid=eid,
             created_at=expected_datetime,
             updated_at=expected_datetime,
         )
 
-    monkeypatch.setattr(AqueductClient, "get_experiment_by_alias", patched_get_experiment)
+    monkeypatch.setattr(AqueductClient, "get_experiment_by_eid", patched_get_experiment)
     monkeypatch.setattr(AqueductClient, "remove_experiment", patched_remove_experiment)
     api = API(url="http://test.com", timeout=1)
 
-    api.remove_experiment_by_alias(alias=expected_alias)
+    api.remove_experiment_by_eid(eid=expected_eid)
 
 
 def test_find_experiments(monkeypatch):
     ExperimentMockData = namedtuple(
         "ExperimentData",
-        "expected_id expected_title expected_description expected_alias expected_datetime",
+        "expected_uuid expected_title expected_description expected_eid expected_datetime",
     )
     experiments_list = []
     for _ in range(3):
         new_experiment = ExperimentMockData(
-            uuid4(), "test title", "test description", "mock_alias", datetime.now()
+            uuid4(), "test title", "test description", "mock_eid", datetime.now()
         )
         experiments_list.append(new_experiment)
 
@@ -109,10 +109,10 @@ def test_find_experiments(monkeypatch):
         return ExperimentsInfo(
             experiments=[
                 ExperimentData(
-                    id=item.expected_id,
+                    uuid=item.expected_uuid,
                     title=item.expected_title,
                     description=item.expected_description,
-                    alias=item.expected_alias,
+                    eid=item.expected_eid,
                     created_at=item.expected_datetime,
                     updated_at=item.expected_datetime,
                 )
@@ -127,6 +127,6 @@ def test_find_experiments(monkeypatch):
     experiments = api.find_experiments(search="test title", limit=3)
 
     for experiment, expected_exp in zip(experiments, experiments_list):
-        assert experiment.alias == expected_exp.expected_alias
-        assert experiment.id == expected_exp.expected_id
+        assert experiment.eid == expected_exp.expected_eid
+        assert experiment.uuid == expected_exp.expected_uuid
         assert experiment.created_at == expected_exp.expected_datetime

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -101,10 +101,10 @@ def test_get_experiments_with_filters(monkeypatch):
             "experiments": {
                 "experimentsData": [
                     {
-                        "id": f"{uuid4()}",
+                        "uuid": f"{uuid4()}",
                         "title": f"test title {idx}",
                         "description": f"test description {idx}",
-                        "alias": f"230101-0{idx}",
+                        "eid": f"230101-0{idx}",
                         "tags": [],
                         "createdAt": "2023-01-01T00:00:00",
                         "updatedAt": "2023-01-01T00:00:00",
@@ -149,8 +149,8 @@ def test_remove_experiment(monkeypatch):
     experiment_id = uuid4()
 
     def patched_execute(self, query, variable_values, **kwargs):
-        if variable_values["experimentId"]:
-            assert variable_values["experimentId"] == str(experiment_id)
+        if variable_values["uuid"]:
+            assert variable_values["uuid"] == str(experiment_id)
 
     monkeypatch.setattr(SyncClientSession, "execute", patched_execute)
 

--- a/tests/unittests/test_experiment.py
+++ b/tests/unittests/test_experiment.py
@@ -11,16 +11,16 @@ def test_experiment_title(monkeypatch):
     expected_id = uuid4()
     expected_title = "test title"
     expected_description = "test description"
-    expected_alias = "test_alias"
+    expected_eid = "test_eid"
     expected_creation_datetime = datetime.now()
     expected_updated_datetime = datetime.now()
 
     def patched_get_experiment(self, experiment_uuid):
         return ExperimentData(
-            id=experiment_uuid,
+            uuid=experiment_uuid,
             title=expected_title,
             description=expected_description,
-            alias=expected_alias,
+            eid=expected_eid,
             created_at=expected_creation_datetime,
             updated_at=expected_updated_datetime,
         )
@@ -28,10 +28,10 @@ def test_experiment_title(monkeypatch):
     def patched_update_experiment(self, experiment_uuid, title):
         assert title == "new title"
         return ExperimentData(
-            id=experiment_uuid,
+            uuid=experiment_uuid,
             title=title,
             description=expected_description,
-            alias=expected_alias,
+            eid=expected_eid,
             created_at=expected_creation_datetime,
             updated_at=expected_updated_datetime,
         )
@@ -41,8 +41,8 @@ def test_experiment_title(monkeypatch):
     mocked_client = AqueductClient(url="http://test.com", timeout=1)
     experiment = Experiment(
         client=mocked_client,
-        experiment_id=expected_id,
-        alias=expected_alias,
+        uuid=expected_id,
+        eid=expected_eid,
         created_at=datetime.now(),
     )
 
@@ -55,15 +55,15 @@ def test_experiment_description(monkeypatch):
     expected_id = uuid4()
     expected_title = "test title"
     expected_description = "test description"
-    expected_alias = "test_alias"
+    expected_eid = "test_eid"
     expected_datetime = datetime.now()
 
     def patched_get_experiment(self, experiment_uuid):
         return ExperimentData(
-            id=experiment_uuid,
+            uuid=experiment_uuid,
             title=expected_title,
             description=expected_description,
-            alias=expected_alias,
+            eid=expected_eid,
             created_at=expected_datetime,
             updated_at=expected_datetime,
         )
@@ -71,10 +71,10 @@ def test_experiment_description(monkeypatch):
     def patched_update_experiment(self, experiment_uuid, description):
         assert description == "new description"
         return ExperimentData(
-            id=experiment_uuid,
+            uuid=experiment_uuid,
             title=expected_title,
             description=description,
-            alias=expected_alias,
+            eid=expected_eid,
             created_at=expected_datetime,
             updated_at=expected_datetime,
         )
@@ -84,8 +84,8 @@ def test_experiment_description(monkeypatch):
     mocked_client = AqueductClient(url="http://test.com", timeout=1)
     experiment = Experiment(
         client=mocked_client,
-        experiment_id=expected_id,
-        alias=expected_alias,
+        uuid=expected_id,
+        eid=expected_eid,
         created_at=datetime.now(),
     )
 
@@ -97,16 +97,16 @@ def test_experiment_tags(monkeypatch):
     expected_id = uuid4()
     expected_title = "test title"
     expected_description = "test description"
-    expected_alias = "test_alias"
+    expected_eid = "test_eid"
     expected_datetime = datetime.now()
     expected_tags = ["tag1", "tag2", "tag3"]
 
     def patched_get_experiment(self, experiment_uuid):
         return ExperimentData(
-            id=experiment_uuid,
+            uuid=experiment_uuid,
             title=expected_title,
             description=expected_description,
-            alias=expected_alias,
+            eid=expected_eid,
             created_at=expected_datetime,
             updated_at=expected_datetime,
             tags=expected_tags,
@@ -116,10 +116,10 @@ def test_experiment_tags(monkeypatch):
         assert tags == ["tag4", "tag5"]
         expected_tags.extend(tags)
         return ExperimentData(
-            id=experiment_uuid,
+            uuid=experiment_uuid,
             title=expected_title,
             description=expected_description,
-            alias=expected_alias,
+            eid=expected_eid,
             created_at=expected_datetime,
             updated_at=expected_datetime,
             tags=expected_tags,
@@ -129,10 +129,10 @@ def test_experiment_tags(monkeypatch):
         assert tag == "tag4"
         expected_tags.remove(tag)
         return ExperimentData(
-            id=experiment_uuid,
+            uuid=experiment_uuid,
             title=expected_title,
             description=expected_description,
-            alias=expected_alias,
+            eid=expected_eid,
             created_at=expected_datetime,
             updated_at=expected_datetime,
             tags=expected_tags,
@@ -146,8 +146,8 @@ def test_experiment_tags(monkeypatch):
     mocked_client = AqueductClient(url="http://test.com", timeout=1)
     experiment = Experiment(
         client=mocked_client,
-        experiment_id=expected_id,
-        alias=expected_alias,
+        uuid=expected_id,
+        eid=expected_eid,
         created_at=datetime.now(),
     )
 
@@ -164,17 +164,17 @@ def test_experiment_files(monkeypatch):
     expected_id = uuid4()
     expected_title = "test title"
     expected_description = "test description"
-    expected_alias = "test_alias"
+    expected_eid = "test_eid"
     expected_datetime = datetime.now()
     expected_tags = ["tag1", "tag2", "tag3"]
     expected_files = [ExperimentFile(name="file1", path="path1", modified_at=datetime.now())]
 
     def patched_get_experiment(self, experiment_uuid):
         return ExperimentData(
-            id=experiment_uuid,
+            uuid=experiment_uuid,
             title=expected_title,
             description=expected_description,
-            alias=expected_alias,
+            eid=expected_eid,
             created_at=expected_datetime,
             updated_at=expected_datetime,
             tags=expected_tags,
@@ -197,8 +197,8 @@ def test_experiment_files(monkeypatch):
     mocked_client = AqueductClient(url="http://test.com", timeout=1)
     experiment = Experiment(
         client=mocked_client,
-        experiment_id=expected_id,
-        alias=expected_alias,
+        uuid=expected_id,
+        eid=expected_eid,
         created_at=datetime.now(),
     )
 


### PR DESCRIPTION
This PR corresponds to the changes in the renaming of the alias to eid and id to uuid on Aqueduct core. I have also added the generation of tutorial markdown from jupyter notebooks to the CI pipeline.