### PR TITLE
feat(ci): Aqueduct integration tests infrastructure

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -64,3 +64,11 @@ jobs:
 
       - name: Run unit tests and build coverage report
         run: ci/pylint.sh
+
+  integration_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run unit tests and build coverage report
+        run: ci/integration_tests.sh

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  pytest:
+  unit_tests:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
@@ -70,5 +70,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Run unit tests and build coverage report
+      - name: Run integration tests
         run: ci/integration_tests.sh

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,5 +37,7 @@
     ],
     "cSpell.words": [
         "PyAqueduct"
-    ]
+    ],
+    "files.insertFinalNewline": true,
+    "notebook.insertFinalNewline": true,
 }

--- a/ci/integration_tests.sh
+++ b/ci/integration_tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+FULL_PATH=$(realpath $0)
+SCRIPT_DIR=$(dirname $FULL_PATH)
+PROJECT_ROOT=$SCRIPT_DIR/..
+set -e
+set -o pipefail
+
+cd $PROJECT_ROOT
+
+mkdir -p /tmp/aqueduct_experiments && \
+mkdir -p /tmp/aqueduct_extensions
+
+echo "Building the stack"
+docker-compose -f $PROJECT_ROOT/containers/integration_tests/docker-compose.yml up -d
+
+# echo "Fixing permissions"
+# sudo chmod -R 777 .
+
+echo "Installing dependencies"
+docker exec --workdir /workspace pyaqueduct-host-dev poetry install 
+
+echo "Running integration tests"
+docker exec --workdir /workspace pyaqueduct-host-dev ./scripts/run_integration_tests.sh

--- a/ci/integration_tests.sh
+++ b/ci/integration_tests.sh
@@ -13,9 +13,6 @@ mkdir -p /tmp/aqueduct_extensions
 echo "Building the stack"
 docker-compose -f $PROJECT_ROOT/containers/integration_tests/docker-compose.yml up -d
 
-# echo "Fixing permissions"
-# sudo chmod -R 777 .
-
 echo "Installing dependencies"
 docker exec --workdir /workspace pyaqueduct-host-dev poetry install 
 

--- a/containers/integration_tests/Dockerfile
+++ b/containers/integration_tests/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.10-slim-buster
+
+RUN pip install poetry

--- a/containers/integration_tests/docker-compose.yml
+++ b/containers/integration_tests/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
   pyaqueduct_host:
-
     build:
       context: ../..
       dockerfile: containers/integration_tests/Dockerfile
@@ -36,8 +35,8 @@ services:
       - /tmp/aqueduct_experiments:/tmp/aqueduct_experiments
       - /tmp/aqueduct_extensions:/tmp/aqueduct_extensions
 
-    ports:
-      - 80:8000
+    expose:
+      - 8000
 
   postgres:
     image: postgres:15-alpine

--- a/containers/integration_tests/docker-compose.yml
+++ b/containers/integration_tests/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  pyaqueduct_host:
+
+    build:
+      context: ../..
+      dockerfile: containers/integration_tests/Dockerfile
+    # image: python:3.10-slim-buster
+    # user: dev_user
+
+    depends_on:
+      - aqueductcore
+
+    container_name: pyaqueduct-host-dev
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    volumes:
+      # Use a named volume for the source code
+      - ../..:/workspace
+
+  aqueductcore:
+    image: aqueducthub/aqueductcore-dev:latest
+    container_name: aqueductcore-server
+    depends_on:
+      - postgres
+    environment:
+      EXPERIMENTS_DIR_PATH: /tmp/aqueduct_experiments
+      EXTENSIONS_DIR_PATH: /tmp/aqueduct_extensions
+      POSTGRES_USERNAME: admin
+      POSTGRES_PASSWORD: admin
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DB: aqueduct
+
+    volumes:
+      - /tmp/aqueduct_experiments:/tmp/aqueduct_experiments
+      - /tmp/aqueduct_extensions:/tmp/aqueduct_extensions
+
+    ports:
+      - 80:8000
+
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=admin
+      - POSTGRES_PASSWORD=admin
+      - POSTGRES_DB=aqueduct
+    expose:
+      - 5432

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Runs Python unit tests using pytest.
+
+FULL_PATH=$(realpath $0)
+SCRIPT_DIR=$(dirname $FULL_PATH)
+PROJECT_ROOT=$SCRIPT_DIR/..
+
+
+poetry run pytest $PROJECT_ROOT/tests/integration -rA -vv

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,189 +1,66 @@
 # pylint: skip-file
-from collections import namedtuple
-from datetime import datetime
-from uuid import uuid4
 
-from gql.client import SyncClientSession
 
 from pyaqueduct.api import API
-from pyaqueduct.client import AqueductClient, ExperimentData, ExperimentsInfo
-from pyaqueduct.extensions import Extension, ExtensionAction
-from tests.unittests.mock import patched_execute
 
 
-def test_create_experiment(monkeypatch):
+def check_experiments(experiment, expected_experiment):
+    assert expected_experiment.eid == experiment.eid
+    assert expected_experiment.title == experiment.title
+    assert expected_experiment.description == experiment.description
+    assert expected_experiment.files == experiment.files
+    assert expected_experiment.uuid == experiment.uuid
+    assert expected_experiment.created_at == experiment.created_at
+    assert expected_experiment.updated_at == experiment.updated_at
+
+
+def test_experiment_flow():
     expected_title = "test title"
     expected_description = "test description"
 
-    expected_uuid = uuid4()
-    expected_eid = "mock_eid"
-    expected_datetime = datetime.now()
-
-    def patched_create_experiment(self, title, description):
-        assert title == expected_title
-        assert description == expected_description
-        return ExperimentData(
-            uuid=expected_uuid,
-            title=expected_title,
-            description=expected_description,
-            eid=expected_eid,
-            created_at=expected_datetime,
-            updated_at=expected_datetime,
-        )
-
-    monkeypatch.setattr(AqueductClient, "create_experiment", patched_create_experiment)
-    api = API(url="http://test.com", timeout=1)
+    api = API(url="http://aqueductcore:8000", timeout=1)
 
     experiment = api.create_experiment(title=expected_title, description=expected_description)
 
-    assert experiment.eid == expected_eid
-    assert experiment.uuid == expected_uuid
-    assert experiment.created_at == expected_datetime
+    assert experiment.title == expected_title
+    assert experiment.description == expected_description
+
+    experiment_new = api.get_experiment_by_eid(eid=experiment.eid)
+
+    check_experiments(experiment, experiment_new)
+
+    experiment_new = api.get_experiment_by_uuid(uuid=experiment.uuid)
+
+    check_experiments(experiment, experiment_new)
 
 
-def test_get_experiment_by_eid(monkeypatch):
-    expected_uuid = uuid4()
+def test_remove_experiment_by_eid():
     expected_title = "test title"
     expected_description = "test description"
-    expected_eid = "mock_eid"
-    expected_datetime = datetime.now()
 
-    def patched_get_experiment(self, eid):
-        return ExperimentData(
-            uuid=expected_uuid,
-            title=expected_title,
-            description=expected_description,
-            eid=eid,
-            created_at=expected_datetime,
-            updated_at=expected_datetime,
-        )
+    api = API(url="http://aqueductcore:8000", timeout=1)
 
-    monkeypatch.setattr(AqueductClient, "get_experiment_by_eid", patched_get_experiment)
-    api = API(url="http://test.com", timeout=1)
+    experiment = api.create_experiment(title=expected_title, description=expected_description)
 
-    experiment = api.get_experiment_by_eid(eid=expected_eid)
-
-    assert experiment.eid == expected_eid
-    assert experiment.uuid == expected_uuid
-    assert experiment.created_at == expected_datetime
+    api.remove_experiment_by_eid(eid=experiment.eid)
 
 
-def test_get_experiment_by_uuid(monkeypatch):
-    expected_uuid = uuid4()
-    expected_eid = "test eid"
+def test_find_experiments():
     expected_title = "test title"
     expected_description = "test description"
-    expected_eid = "mock_eid"
-    expected_datetime = datetime.now()
 
-    def patched_get_experiment(self, experiment_uuid):
-        return ExperimentData(
-            uuid=experiment_uuid,
-            title=expected_title,
-            description=expected_description,
-            eid=expected_eid,
-            created_at=expected_datetime,
-            updated_at=expected_datetime,
-        )
-
-    monkeypatch.setattr(AqueductClient, "get_experiment", patched_get_experiment)
-    api = API(url="http://test.com", timeout=1)
-
-    experiment = api.get_experiment_by_uuid(uuid=expected_uuid)
-
-    assert experiment.eid == expected_eid
-    assert experiment.uuid == expected_uuid
-    assert experiment.created_at == expected_datetime
-
-
-def test_remove_experiment_by_eid(monkeypatch):
-    expected_uuid = uuid4()
-    expected_title = "test title"
-    expected_description = "test description"
-    expected_eid = "mock_eid"
-    expected_datetime = datetime.now()
-
-    def patched_remove_experiment(self, experiment_uuid):
-        assert experiment_uuid == expected_uuid
-
-    def patched_get_experiment(self, eid):
-        assert eid == expected_eid
-
-        return ExperimentData(
-            uuid=expected_uuid,
-            title=expected_title,
-            description=expected_description,
-            eid=eid,
-            created_at=expected_datetime,
-            updated_at=expected_datetime,
-        )
-
-    monkeypatch.setattr(AqueductClient, "get_experiment_by_eid", patched_get_experiment)
-    monkeypatch.setattr(AqueductClient, "remove_experiment", patched_remove_experiment)
-    api = API(url="http://test.com", timeout=1)
-
-    api.remove_experiment_by_eid(eid=expected_eid)
-
-
-def test_find_experiments(monkeypatch):
-    ExperimentMockData = namedtuple(
-        "ExperimentData",
-        "expected_uuid expected_title expected_description expected_eid expected_datetime",
-    )
     experiments_list = []
+
+    api = API(url="http://aqueductcore:8000", timeout=1)
+
     for _ in range(3):
-        new_experiment = ExperimentMockData(
-            uuid4(), "test title", "test description", "mock_eid", datetime.now()
-        )
-        experiments_list.append(new_experiment)
+        experiment = api.create_experiment(title=expected_title, description=expected_description)
+        experiments_list.append(experiment)
 
-    def patched_get_experiments(self, title, limit, offset, tags, start_datetime, end_datetime):
-        return ExperimentsInfo(
-            experiments=[
-                ExperimentData(
-                    uuid=item.expected_uuid,
-                    title=item.expected_title,
-                    description=item.expected_description,
-                    eid=item.expected_eid,
-                    created_at=item.expected_datetime,
-                    updated_at=item.expected_datetime,
-                )
-                for item in experiments_list
-            ][offset:limit],
-            total_count=limit,
-        )
+    experiments = api.find_experiments(search=expected_title, limit=10)
 
-    monkeypatch.setattr(AqueductClient, "get_experiments", patched_get_experiments)
-    api = API(url="http://test.com", timeout=1)
-
-    experiments = api.find_experiments(search="test title", limit=3)
+    # reverse them list to match the order returned by the server (order by creation date)
+    experiments_list.reverse()
 
     for experiment, expected_exp in zip(experiments, experiments_list):
-        assert experiment.eid == expected_exp.expected_eid
-        assert experiment.uuid == expected_exp.expected_uuid
-        assert experiment.created_at == expected_exp.expected_datetime
-
-
-def test_get_extensions(monkeypatch):
-    monkeypatch.setattr(SyncClientSession, "execute", patched_execute)
-    api = API(url="http://test.com", timeout=1)
-    extensions = api.get_extensions()
-    assert len(extensions) == 1
-    assert isinstance(extensions[0], Extension)
-    assert len(extensions[0].actions) == 2
-    assert isinstance(extensions[0].actions[0], ExtensionAction)
-    assert extensions[0].actions[0].name == "echo"
-    assert extensions[0].actions[0].description == "Print values to stdout"
-    assert extensions[0].actions[0].experiment_variable_name == "var4"
-    assert extensions[0].actions[0].parameters[-1].dataType == "select"
-    assert extensions[0].actions[0].parameters[-1].options[1] == "string2"
-
-
-def test_execute_extension_action(monkeypatch):
-    monkeypatch.setattr(SyncClientSession, "execute", patched_execute)
-    api = API(url="http://test.com", timeout=1)
-    extensions = api.get_extensions()
-    result = extensions[0].actions[0].execute({"var1": 1})
-    assert result.returnCode == 0
-    assert result.stdout != ""
-    assert result.stderr == ""
+        check_experiments(experiment, expected_exp)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,0 +1,189 @@
+# pylint: skip-file
+from collections import namedtuple
+from datetime import datetime
+from uuid import uuid4
+
+from gql.client import SyncClientSession
+
+from pyaqueduct.api import API
+from pyaqueduct.client import AqueductClient, ExperimentData, ExperimentsInfo
+from pyaqueduct.extensions import Extension, ExtensionAction
+from tests.unittests.mock import patched_execute
+
+
+def test_create_experiment(monkeypatch):
+    expected_title = "test title"
+    expected_description = "test description"
+
+    expected_uuid = uuid4()
+    expected_eid = "mock_eid"
+    expected_datetime = datetime.now()
+
+    def patched_create_experiment(self, title, description):
+        assert title == expected_title
+        assert description == expected_description
+        return ExperimentData(
+            uuid=expected_uuid,
+            title=expected_title,
+            description=expected_description,
+            eid=expected_eid,
+            created_at=expected_datetime,
+            updated_at=expected_datetime,
+        )
+
+    monkeypatch.setattr(AqueductClient, "create_experiment", patched_create_experiment)
+    api = API(url="http://test.com", timeout=1)
+
+    experiment = api.create_experiment(title=expected_title, description=expected_description)
+
+    assert experiment.eid == expected_eid
+    assert experiment.uuid == expected_uuid
+    assert experiment.created_at == expected_datetime
+
+
+def test_get_experiment_by_eid(monkeypatch):
+    expected_uuid = uuid4()
+    expected_title = "test title"
+    expected_description = "test description"
+    expected_eid = "mock_eid"
+    expected_datetime = datetime.now()
+
+    def patched_get_experiment(self, eid):
+        return ExperimentData(
+            uuid=expected_uuid,
+            title=expected_title,
+            description=expected_description,
+            eid=eid,
+            created_at=expected_datetime,
+            updated_at=expected_datetime,
+        )
+
+    monkeypatch.setattr(AqueductClient, "get_experiment_by_eid", patched_get_experiment)
+    api = API(url="http://test.com", timeout=1)
+
+    experiment = api.get_experiment_by_eid(eid=expected_eid)
+
+    assert experiment.eid == expected_eid
+    assert experiment.uuid == expected_uuid
+    assert experiment.created_at == expected_datetime
+
+
+def test_get_experiment_by_uuid(monkeypatch):
+    expected_uuid = uuid4()
+    expected_eid = "test eid"
+    expected_title = "test title"
+    expected_description = "test description"
+    expected_eid = "mock_eid"
+    expected_datetime = datetime.now()
+
+    def patched_get_experiment(self, experiment_uuid):
+        return ExperimentData(
+            uuid=experiment_uuid,
+            title=expected_title,
+            description=expected_description,
+            eid=expected_eid,
+            created_at=expected_datetime,
+            updated_at=expected_datetime,
+        )
+
+    monkeypatch.setattr(AqueductClient, "get_experiment", patched_get_experiment)
+    api = API(url="http://test.com", timeout=1)
+
+    experiment = api.get_experiment_by_uuid(uuid=expected_uuid)
+
+    assert experiment.eid == expected_eid
+    assert experiment.uuid == expected_uuid
+    assert experiment.created_at == expected_datetime
+
+
+def test_remove_experiment_by_eid(monkeypatch):
+    expected_uuid = uuid4()
+    expected_title = "test title"
+    expected_description = "test description"
+    expected_eid = "mock_eid"
+    expected_datetime = datetime.now()
+
+    def patched_remove_experiment(self, experiment_uuid):
+        assert experiment_uuid == expected_uuid
+
+    def patched_get_experiment(self, eid):
+        assert eid == expected_eid
+
+        return ExperimentData(
+            uuid=expected_uuid,
+            title=expected_title,
+            description=expected_description,
+            eid=eid,
+            created_at=expected_datetime,
+            updated_at=expected_datetime,
+        )
+
+    monkeypatch.setattr(AqueductClient, "get_experiment_by_eid", patched_get_experiment)
+    monkeypatch.setattr(AqueductClient, "remove_experiment", patched_remove_experiment)
+    api = API(url="http://test.com", timeout=1)
+
+    api.remove_experiment_by_eid(eid=expected_eid)
+
+
+def test_find_experiments(monkeypatch):
+    ExperimentMockData = namedtuple(
+        "ExperimentData",
+        "expected_uuid expected_title expected_description expected_eid expected_datetime",
+    )
+    experiments_list = []
+    for _ in range(3):
+        new_experiment = ExperimentMockData(
+            uuid4(), "test title", "test description", "mock_eid", datetime.now()
+        )
+        experiments_list.append(new_experiment)
+
+    def patched_get_experiments(self, title, limit, offset, tags, start_datetime, end_datetime):
+        return ExperimentsInfo(
+            experiments=[
+                ExperimentData(
+                    uuid=item.expected_uuid,
+                    title=item.expected_title,
+                    description=item.expected_description,
+                    eid=item.expected_eid,
+                    created_at=item.expected_datetime,
+                    updated_at=item.expected_datetime,
+                )
+                for item in experiments_list
+            ][offset:limit],
+            total_count=limit,
+        )
+
+    monkeypatch.setattr(AqueductClient, "get_experiments", patched_get_experiments)
+    api = API(url="http://test.com", timeout=1)
+
+    experiments = api.find_experiments(search="test title", limit=3)
+
+    for experiment, expected_exp in zip(experiments, experiments_list):
+        assert experiment.eid == expected_exp.expected_eid
+        assert experiment.uuid == expected_exp.expected_uuid
+        assert experiment.created_at == expected_exp.expected_datetime
+
+
+def test_get_extensions(monkeypatch):
+    monkeypatch.setattr(SyncClientSession, "execute", patched_execute)
+    api = API(url="http://test.com", timeout=1)
+    extensions = api.get_extensions()
+    assert len(extensions) == 1
+    assert isinstance(extensions[0], Extension)
+    assert len(extensions[0].actions) == 2
+    assert isinstance(extensions[0].actions[0], ExtensionAction)
+    assert extensions[0].actions[0].name == "echo"
+    assert extensions[0].actions[0].description == "Print values to stdout"
+    assert extensions[0].actions[0].experiment_variable_name == "var4"
+    assert extensions[0].actions[0].parameters[-1].dataType == "select"
+    assert extensions[0].actions[0].parameters[-1].options[1] == "string2"
+
+
+def test_execute_extension_action(monkeypatch):
+    monkeypatch.setattr(SyncClientSession, "execute", patched_execute)
+    api = API(url="http://test.com", timeout=1)
+    extensions = api.get_extensions()
+    result = extensions[0].actions[0].execute({"var1": 1})
+    assert result.returnCode == 0
+    assert result.stdout != ""
+    assert result.stderr == ""


### PR DESCRIPTION
This PR adds the infrastructure for running integration tests with the latest development version of the Aqueduct core. Integration tests for experiments API are also added. In the future, integration tests regarding plugins should be added, which I didn't cover in this PR, as it requires further thought of what plugins to use and how to add dependency to these tests. 