### PR TITLE
feat(files): Remove files from experiments

### DIFF
--- a/ci/integration_tests.sh
+++ b/ci/integration_tests.sh
@@ -16,5 +16,7 @@ docker-compose -f $PROJECT_ROOT/containers/integration_tests/docker-compose.yml 
 echo "Installing dependencies"
 docker exec --workdir /workspace pyaqueduct-host-dev poetry install 
 
+sleep 5s
+
 echo "Running integration tests"
 docker exec --workdir /workspace pyaqueduct-host-dev ./scripts/run_integration_tests.sh

--- a/pyaqueduct/exceptions.py
+++ b/pyaqueduct/exceptions.py
@@ -27,3 +27,7 @@ class FileUploadError(PyAqueductError):
 
 class FileDownloadError(PyAqueductError):
     """Interrupted download error."""
+
+
+class FileRemovalError(PyAqueductError):
+    """File removal error."""

--- a/pyaqueduct/experiment.py
+++ b/pyaqueduct/experiment.py
@@ -79,6 +79,16 @@ class Experiment(BaseModel):
         """Remove tag from experiment."""
         self._client.remove_tag_from_experiment(experiment_uuid=self.uuid, tag=tag)
 
+    @validate_call
+    def remove_files(self, files: List[str]) -> None:
+        """Remove files from experiment.
+
+        Args:
+            files: List of file names to be removed from the experiment.
+
+        """
+        self._client.remove_files_from_experiment(experiment_uuid=self.uuid, files=files)
+
     @property
     def files(self) -> List[Tuple[str, datetime]]:
         """Get file names of expriment."""


### PR DESCRIPTION
This PR adds the new method to the experiment object that lets the user to remove files from an experiment by passing a list of file names.